### PR TITLE
graphql-schema: DataLanguageResolver: uniformization of return code

### DIFF
--- a/packages/graphql-schema/src/metadata/DataLanguageResolver.ts
+++ b/packages/graphql-schema/src/metadata/DataLanguageResolver.ts
@@ -18,8 +18,13 @@ export class DataLanguageResolver {
     @Ctx() ctx: Context,
     @Arg("lang", { nullable: true }) lang?: string,
   ): Promise<Language[]> {
-    return (await ctx.omnipartners.metadata.getMemberLanguages({
+    const languages = (await ctx.omnipartners.metadata.getMemberLanguages({
       lang,
     })).data;
+
+    return languages.map(l => ({
+      ...l,
+      code: l.code.toLowerCase(),
+    }));
   }
 }


### PR DESCRIPTION
return of 

```gql
query {
  metadataLanguages {
    code
  }
}
```
is 

```
{
  "data": {
    "metadataLanguages": [
      {
        "code": "NL"
      },
      {
        "code": "EN"
      },
      {
        "code": "fr"
      }
    ]
  }
}
```