### PR TITLE
graphql-schema: GenericResult: make is internalError optional

### DIFF
--- a/packages/graphql-schema/src/types/GenericResult.ts
+++ b/packages/graphql-schema/src/types/GenericResult.ts
@@ -24,7 +24,7 @@ export abstract class GenericResult<TResult> {
   public error?: GenericError;
   public result?: TResult;
   constructor({ error, result }: { error?: any; result?: TResult }) {
-    if (error && this.isInternalError(error)) {
+    if (error && this.isInternalError && this.isInternalError(error)) {
       throw error;
     }
 
@@ -36,7 +36,7 @@ export abstract class GenericResult<TResult> {
     this.result = result;
   }
 
-  public isInternalError(error: any) {
+  public isInternalError?(error: any) {
     return (
       !(error instanceof OmnipartnersError) &&
       !(error instanceof AuthenticationError)


### PR DESCRIPTION
Fix Property 'isInternalError' is missing in type '{}' but required in type 'CustomOmnipartnerResult'