### PR TITLE
graphql-schema: GenericResult: remove question mark on `isInternalError`

### DIFF
--- a/packages/graphql-schema/src/types/GenericResult.ts
+++ b/packages/graphql-schema/src/types/GenericResult.ts
@@ -36,7 +36,7 @@ export abstract class GenericResult<TResult> {
     this.result = result;
   }
 
-  public isInternalError?(error: any) {
+  public isInternalError(error: any) {
     const originalError = error instanceof GenericError ? error.error : error
     return (
       !(originalError instanceof OmnipartnersError) &&


### PR DESCRIPTION
Otherwise it makes difficult to overwrite `isInternalError` in a child class.
But it demonstrate that we should always return a `new GenericResult()` in resolvers.